### PR TITLE
Fixed a bug

### DIFF
--- a/config.json.sample
+++ b/config.json.sample
@@ -29,6 +29,8 @@
      * limit thershold within given time
      *
      */
+    "attempt_timeout": 1,
+    "attempt_max_bytes": 512,
     "attempt_thershold": 3,
     "attempt_expire": 3600,
     "attempt_restrict": 86400,

--- a/trap/config/config.go
+++ b/trap/config/config.go
@@ -39,6 +39,8 @@ type Config struct {
 
     Listens             Listens
 
+    AttemptTimeout      types.UInt32
+    AttemptMaxBytes     types.UInt32
     AttemptThershold    types.UInt32
     AttemptExpire       types.UInt32
     AttemptRestrict     types.UInt32

--- a/trap/config/loader.go
+++ b/trap/config/loader.go
@@ -19,6 +19,8 @@ type rawConfig struct {
 
     Listens             []types.String      `json:"listen_ports"`
 
+    AttemptTimeout      types.UInt32        `json:"attempt_timeout"`
+    AttemptMaxBytes     types.UInt32        `json:"attempt_max_bytes"`
     AttemptThershold    types.UInt32        `json:"attempt_thershold"`
     AttemptExpire       types.UInt32        `json:"attempt_expire"`
     AttemptRestrict     types.UInt32        `json:"attempt_restrict"`
@@ -104,6 +106,12 @@ func Parse(configStr []byte) (*Config, *types.Throw) {
 
         config.Listens          =   append(config.Listens, listenItem)
     }
+
+    // Parse `AttemptTimeout` Field
+    config.AttemptTimeout       =   rawConfig.AttemptTimeout
+
+    // Parse `AttemptMaxBytes` Field
+    config.AttemptMaxBytes      =   rawConfig.AttemptMaxBytes
 
     // Parse `AttemptThershold` Field
     config.AttemptThershold = rawConfig.AttemptThershold

--- a/trap/core/client/client.go
+++ b/trap/core/client/client.go
@@ -49,7 +49,7 @@ func (c *Client) Bump() {
 }
 
 func (c *Client) AppendData(data Data, maxLen types.UInt16) {
-    dataLen                 :=  types.UInt16(len(c.Data))
+    dataLen                 :=  types.Int32(len(c.Data)).UInt16()
 
     c.Data                  =   append(c.Data, data)
 

--- a/trap/core/listen/config.go
+++ b/trap/core/listen/config.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-    _                       = iota
+    _                       =   iota
 
     RESPOND_SUGGEST_SKIP
     RESPOND_SUGGEST_MARK
@@ -43,6 +43,8 @@ type Config struct {
     OnListened      func(*ListeningInfo)
     OnUnListened    func(*ListeningInfo)
 
+    MaxBytes        types.UInt32
+
     Logger          *logger.Logger
     Concurrent      types.UInt16
 
@@ -51,10 +53,12 @@ type Config struct {
 
 type ListenerConfig struct {
     Logger          *logger.Logger
-    Concurrent      uint
+    Concurrent      types.UInt16
 
     OnError         func(ConnectionInfo, *types.Throw)
     OnPick          func(ConnectionInfo, RespondedResult)
+
+    MaxBytes        types.UInt32
 
     ReadTimeout     time.Duration
     WriteTimeout    time.Duration
@@ -70,6 +74,8 @@ type ProtocolConfig struct {
 
     OnError         func(ConnectionInfo, *types.Throw)
     OnPick          func(ConnectionInfo, RespondedResult)
+
+    MaxBytes        types.UInt32
 
     ReadTimeout     time.Duration
     WriteTimeout    time.Duration
@@ -91,11 +97,8 @@ type ConnectionInfo struct {
 }
 
 type RespondedResult struct {
-    ReceivedSample  [512]byte
-    ReceivedLen     int
-
-    RespondedData   [512]byte
-    RespondedLen    int
+    ReceivedSample  []byte
+    RespondedData   []byte
 
     Suggestion      int
 }

--- a/trap/core/listen/listen.go
+++ b/trap/core/listen/listen.go
@@ -48,6 +48,8 @@ type Listen struct {
 
     error           *types.Throw
 
+    maxBytes        types.UInt32
+
     protocols       Protocols
 
     onError         func(ConnectionInfo, *types.Throw)
@@ -77,6 +79,8 @@ func (this *Listen) Init(cfg *Config) {
     this.onListened     = cfg.OnListened
     this.onUnListened   = cfg.OnUnListened
 
+    this.maxBytes       = cfg.MaxBytes
+
     this.concurrent     = cfg.Concurrent
 }
 
@@ -96,6 +100,8 @@ func (this *Listen) Register(pType types.String, protocol Protocol) (*types.Thro
     protocol.Init(&ProtocolConfig{
         OnError:        this.onError,
         OnPick:         this.onPick,
+
+        MaxBytes:       this.maxBytes,
 
         ReadTimeout:    this.timeout,
         WriteTimeout:   this.timeout,

--- a/trap/protocol/tcp/config.go
+++ b/trap/protocol/tcp/config.go
@@ -30,3 +30,7 @@ type ListenerConfig struct {
 
     Responder       Responder
 }
+
+type ResponderConfig struct {
+    MaxBytes        uint
+}

--- a/trap/protocol/tcp/responder.go
+++ b/trap/protocol/tcp/responder.go
@@ -29,5 +29,6 @@ import (
 )
 
 type Responder interface {
-    Handle(*net.TCPConn) (listen.RespondedResult, *types.Throw)
+    Handle(*net.TCPConn, *ResponderConfig) (listen.RespondedResult,
+        *types.Throw)
 }

--- a/trap/protocol/tcp/responder/empty.go
+++ b/trap/protocol/tcp/responder/empty.go
@@ -24,6 +24,7 @@ package responder
 import (
     "github.com/raincious/trap/trap/core/types"
     "github.com/raincious/trap/trap/core/listen"
+    "github.com/raincious/trap/trap/protocol/tcp"
 
     "io"
     "net"
@@ -33,20 +34,26 @@ type Empty struct {
 
 }
 
-func (e *Empty) Handle(conn *net.TCPConn) (listen.RespondedResult, *types.Throw) {
-    var totalbuffer []byte
+func (e *Empty) Handle(conn *net.TCPConn,
+    config *tcp.ResponderConfig) (listen.RespondedResult, *types.Throw) {
+    readLen                     :=  uint(256)
 
-    result                  :=  listen.RespondedResult{
-                                    Suggestion: listen.RESPOND_SUGGEST_MARK,
-                                }
+    result                      :=  listen.RespondedResult{
+                                        Suggestion: listen.RESPOND_SUGGEST_MARK,
+                                        ReceivedSample: []byte{},
+                                    }
 
-    totalLen                :=  0
-    maxLen                  :=  len(result.ReceivedSample)
+    totalLen                    :=  uint(0)
+    maxLen                      :=  config.MaxBytes
+
+    if maxLen < 256 {
+        readLen                 =   maxLen
+    }
 
     for {
-        buffer              :=  make([]byte, 256)
+        buffer                  :=  make([]byte, readLen)
 
-        rLen, rErr          :=  conn.Read(buffer)
+        rLen, rErr              :=  conn.Read(buffer)
 
         if rErr == io.EOF {
             break
@@ -58,18 +65,15 @@ func (e *Empty) Handle(conn *net.TCPConn) (listen.RespondedResult, *types.Throw)
             return result, types.ConvertError(rErr)
         }
 
-        totalLen            +=  rLen
+        totalLen                +=  uint(rLen)
 
         if totalLen > maxLen {
             break
         }
 
-        totalbuffer         =   append(totalbuffer, buffer[:rLen]...)
+        result.ReceivedSample   =   append(result.ReceivedSample,
+                                        buffer[:rLen]...)
     }
-
-    result.ReceivedLen      =   totalLen
-
-    copy(result.ReceivedSample[:], totalbuffer)
 
     return result, nil
 }

--- a/trap/protocol/udp/udp.go
+++ b/trap/protocol/udp/udp.go
@@ -34,6 +34,8 @@ type UDP struct {
     onError         func(listen.ConnectionInfo, *types.Throw)
     onPick          func(listen.ConnectionInfo, listen.RespondedResult)
 
+    maxBytes        types.UInt32
+
     readTimeout     time.Duration
     writeTimeout    time.Duration
     totalTimeout    time.Duration
@@ -41,7 +43,7 @@ type UDP struct {
     inited          bool
 
     logger          *logger.Logger
-    concurrent      uint
+    concurrent      types.UInt16
 }
 
 func (t *UDP) Init(c *listen.ProtocolConfig) (*types.Throw) {
@@ -53,13 +55,15 @@ func (t *UDP) Init(c *listen.ProtocolConfig) (*types.Throw) {
 
     t.logger            = c.Logger.NewContext("UDP")
 
+    t.maxBytes          = c.MaxBytes
+
     t.onError           = c.OnError
     t.onPick            = c.OnPick
 
     t.readTimeout       = c.ReadTimeout
     t.writeTimeout      = c.WriteTimeout
     t.totalTimeout      = c.TotalTimeout
-    t.concurrent        = uint(c.Concurrent.UInt16())
+    t.concurrent        = c.Concurrent
 
     return nil
 }
@@ -72,6 +76,7 @@ func (t *UDP) Spawn(ip net.IP, port types.UInt16,
         listen.ListenerConfig{
             Logger:         t.logger,
             Concurrent:     t.concurrent,
+            MaxBytes:       t.maxBytes,
 
             OnError:        t.onError,
             OnPick:         t.onPick,


### PR DESCRIPTION
Now we use the right way to calc the length of data which received from the client who connected to our fake service.

'slice bounds out of range' problem now fixed.

Not just that, a configuration option also been added to let user config how long the data we will receive from a client.